### PR TITLE
Fix keyboard release issues and improve properties panel

### DIFF
--- a/src/components/ui/shadcn/tooltip.tsx
+++ b/src/components/ui/shadcn/tooltip.tsx
@@ -46,7 +46,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance',
+          'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs whitespace-pre-wrap text-left',
           className
         )}
         {...props}

--- a/src/core/base/ModuleBase.ts
+++ b/src/core/base/ModuleBase.ts
@@ -61,7 +61,7 @@ export abstract class ModuleBase {
   // 模块类型标识
   public readonly moduleType: string;
   public readonly id: string;
-  public readonly name: string;
+  public name: string;
 
   // 模块参数，使用BehaviorSubject
   public parameters: {
@@ -265,6 +265,10 @@ export abstract class ModuleBase {
         `Parameter type ${paramType} not compatible with port type ${portType}`
       );
     }
+  }
+
+  public setName(newName: string): void {
+    this.name = newName;
   }
 
   /**

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -41,6 +41,7 @@ interface FlowState {
   ) => string;
   addEdge: (source: string, target: string) => void;
   deleteNode: (nodeId: string) => void;
+  renameNode: (nodeId: string, newLabel: string) => void;
 
   // 序列化相关方法
   exportCanvasToJson: () => string;
@@ -173,6 +174,34 @@ export const useFlowStore = create<FlowState>((set, get) => {
         edges: get().edges.filter(
           (e) => e.source !== nodeId && e.target !== nodeId
         ),
+      });
+    },
+
+    renameNode: (nodeId, newLabel) => {
+      const trimmedLabel = newLabel.trim();
+      if (!trimmedLabel) {
+        return;
+      }
+
+      set({
+        nodes: get().nodes.map((node) => {
+          if (node.id !== nodeId) {
+            return node;
+          }
+
+          const moduleInstance = node.data?.module;
+          if (moduleInstance && typeof moduleInstance.setName === 'function') {
+            moduleInstance.setName(trimmedLabel);
+          }
+
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              label: trimmedLabel,
+            },
+          };
+        }),
       });
     },
 


### PR DESCRIPTION
## Summary
- ensure the module properties sidebar stays open without a selection and add a rename field for modules
- prevent stuck notes when clicking different keys on the on-screen keyboard and keep oscillator voices in sync with parameter changes
- fix tooltip text alignment to remove excess whitespace

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dbbaf8229083219d68f3f3af0b4185