### PR TITLE
Fix keyboard velocity mapping and allow audio edge removal

### DIFF
--- a/src/components/ui/contextMenu/hooks/useFlowContextMenu.ts
+++ b/src/components/ui/contextMenu/hooks/useFlowContextMenu.ts
@@ -4,10 +4,12 @@ import { useCallback } from 'react';
 import { Node, Edge, useReactFlow } from '@xyflow/react';
 import { useContextMenu } from './useContextMenu';
 import { MenuItem } from '../types';
+import { useFlowStore } from '@/store/store';
 
 export const useFlowContextMenu = () => {
   const { handleContextMenu } = useContextMenu();
   const reactFlowInstance = useReactFlow();
+  const onEdgesChange = useFlowStore((state) => state.onEdgesChange);
 
   // 处理事件类型的辅助函数
   const handleEvent = (
@@ -120,13 +122,19 @@ export const useFlowContextMenu = () => {
           label: '删除连接',
           onClick: () => {
             console.info('删除连接', edge.id);
+            onEdgesChange([
+              {
+                id: edge.id,
+                type: 'remove',
+              },
+            ]);
           },
         },
       ];
 
       handleContextMenu(handleEvent(event), edgeMenuItems);
     },
-    [handleContextMenu]
+    [handleContextMenu, onEdgesChange]
   );
 
   return {


### PR DESCRIPTION
## Summary
- calculate piano keyboard velocities from pointer position so note-on events reflect click depth
- trigger edge removal from the context menu to break module bindings when a connection is deleted

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68fecf99e71c8329be6cab8d59d5e1b3